### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,11 +5,11 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
+        os: [macos-latest, ubuntu-18.04]
         node-version: [8.x, 10.x]
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,26 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-18.04]
+        node-version: [8.x, 10.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install and build
+      run: |
+        npm ci
+        npm run build --if-present
+      env:
+        CI: true


### PR DESCRIPTION
This pull request adds GitHub Actions to automatically build any commit.

It uses the matrix feature to build for Node 8 and 10 on mac and ubuntu.

Results (on successful build):
<img width="652" alt="Screen Shot 2019-11-13 at 3 59 56 PM" src="https://user-images.githubusercontent.com/402669/68804262-522afd00-062f-11ea-820c-9c3c762bdfaf.png">

Available from Actions tab in GitHub:
<img width="1062" alt="Screen Shot 2019-11-13 at 4 01 06 PM" src="https://user-images.githubusercontent.com/402669/68804289-62db7300-062f-11ea-9916-fa364b6b43e1.png">

Individual Build Results:
<img width="1077" alt="Screen Shot 2019-11-13 at 4 01 56 PM" src="https://user-images.githubusercontent.com/402669/68804383-98805c00-062f-11ea-8544-f070e194a8de.png">

Note: Windows and Node 12 report a failure and so weren't included.